### PR TITLE
Changes applied:

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@
 #   - Section names should be unique on each level.
 
 # Don't edit manually! Use `build.bat version` command instead!
-version: 1.6.2-build-0{build}
+version: 1.6.3-build-0{build}
 
 os: Visual Studio 2015
 

--- a/nuspecs/Hangfire.SqlServer.RabbitMQ.nuspec
+++ b/nuspecs/Hangfire.SqlServer.RabbitMQ.nuspec
@@ -12,28 +12,33 @@
     <description>RabbitMQ queues support for SQL Server job storage implementation for Hangfire (background job system for ASP.NET applications).</description>
     <copyright>Copyright © 2014 Denny Ferrassoli</copyright>
     <tags>Hangfire SqlServer RabbitMQ</tags>
-    <releaseNotes>https://github.com/HangfireIO/Hangfire.SqlServer.RabbitMq/releases
+    <releaseNotes>
+      https://github.com/HangfireIO/Hangfire.SqlServer.RabbitMq/releases
+      
+      1.6.3 (by @dawidvanzyl)
+      * Changed – `Hangfire` dependencies upgraded to >=1.6.15.      
+      * Added   – Implemented RabbitMqExtensions that will allow for the RabbitMq queues to be added with the GlobalConfiguration.Configuration.Use pattern.
+      
+      1.6.2 (by @mthierba)
+      * Changed – New 'PrefetchCount' configuration setting - default value '1' for compatibility with previous releases. Recommended to increase in production.
 
-1.6.2 (by @mthierba)
-* Changed – New 'PrefetchCount' configuration setting - default value '1' for compatibility with previous releases. Recommended to increase in production.
+      1.6.1 (by @mthierba)
+      * Changed – `Hangfire` dependencies upgraded to >=1.6.0.
+      * Changed – `RabbitMq.Client` package updated to 4.1.1.
+      * Changed - NuGet platform now Net451 to be compatible with RabbitMQ.Client 4.x.
+      * Changed - RabbitMqJobQueueProvider now IDisposable to facilitate proper resource lifetime management.
+      * Fixed   – Various reliability and scalability bugs.
 
-1.6.1 (by @mthierba)
-* Changed – `Hangfire` dependencies upgraded to >=1.6.0.
-* Changed – `RabbitMq.Client` package updated to 4.1.1.
-* Changed - NuGet platform now Net451 to be compatible with RabbitMQ.Client 4.x.
-* Changed - RabbitMqJobQueueProvider now IDisposable to facilitate proper resource lifetime management.
-* Fixed   – Various reliability and scalability bugs.
-    
-1.6.0
-* Changed – `Hangfire` dependencies are not strict now.
-* Changed – `RabbitMq.Client` package updated to 3.6.5.
-* Changed – `RabbitMq.Client.dll` assembly merged with `Hangfire.SqlServer.RabbitMq.dll`.
-    
-1.4.2
-* Fixed – Incompatibility issue with RabbitMQ.Client >= 3.4.0 (by @justmara).
-    
-1.4.0
-* Added – Allow a URI to be used for `RabbitMQConnectionConfiguration` (by @dennyferra).
+      1.6.0
+      * Changed – `Hangfire` dependencies are not strict now.
+      * Changed – `RabbitMq.Client` package updated to 3.6.5.
+      * Changed – `RabbitMq.Client.dll` assembly merged with `Hangfire.SqlServer.RabbitMq.dll`.
+
+      1.4.2
+      * Fixed – Incompatibility issue with RabbitMQ.Client >= 3.4.0 (by @justmara).
+
+      1.4.0
+      * Added – Allow a URI to be used for `RabbitMQConnectionConfiguration` (by @dennyferra).
     </releaseNotes>
     <dependencies>
       <dependency id="Hangfire.Core" version="1.6.0" />

--- a/src/Hangfire.SqlServer.RabbitMq/Hangfire.SqlServer.RabbitMq.csproj
+++ b/src/Hangfire.SqlServer.RabbitMq/Hangfire.SqlServer.RabbitMq.csproj
@@ -39,12 +39,12 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Hangfire.Core, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Hangfire.Core.1.6.0\lib\net45\Hangfire.Core.dll</HintPath>
+    <Reference Include="Hangfire.Core, Version=1.6.15.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hangfire.Core.1.6.15\lib\net45\Hangfire.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Hangfire.SqlServer, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Hangfire.SqlServer.1.6.0\lib\net45\Hangfire.SqlServer.dll</HintPath>
+    <Reference Include="Hangfire.SqlServer, Version=1.6.15.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hangfire.SqlServer.1.6.15\lib\net45\Hangfire.SqlServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -74,6 +74,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="RabbitMqConnectionConfiguration.cs" />
+    <Compile Include="RabbitMQExtensions.cs" />
     <Compile Include="RabbitMqFetchedJob.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RabbitMqJobQueue.cs" />

--- a/src/Hangfire.SqlServer.RabbitMq/RabbitMQExtensions.cs
+++ b/src/Hangfire.SqlServer.RabbitMq/RabbitMQExtensions.cs
@@ -1,0 +1,29 @@
+﻿using Hangfire.SqlServer;
+using Hangfire.SqlServer.RabbitMQ;
+using System;
+
+namespace Hangfire
+{
+    public static class RabbitMqExtensions
+    {
+        public static IGlobalConfiguration<SqlServerStorage> UseRabbitMqQueues(this IGlobalConfiguration<SqlServerStorage> configuration, Action<RabbitMqConnectionConfiguration> configureAction, params string[] queues)
+        {
+            if (configuration == null) throw new ArgumentNullException("configuration");
+            if (queues == null) throw new ArgumentNullException("queues");
+            if (queues.Length == 0) throw new ArgumentException("No queue(s) specified for RabbitMQ provider.", "queues");
+            if (configureAction == null) throw new ArgumentNullException("configureAction");
+
+            var conf = new RabbitMqConnectionConfiguration();
+            configureAction(conf);
+
+            var provider = new RabbitMqJobQueueProvider(queues, conf.CreateConnectionFactory(), channel =>
+                channel.BasicQos(0,
+                    conf.PrefetchCount,
+                    false // applied separately to each new consumer on the channel
+                ));
+
+            configuration.Entry.QueueProviders.Add(provider, queues);
+            return configuration;
+        }
+    }
+}

--- a/src/Hangfire.SqlServer.RabbitMq/RabbitMqConnectionConfiguration.cs
+++ b/src/Hangfire.SqlServer.RabbitMq/RabbitMqConnectionConfiguration.cs
@@ -73,5 +73,26 @@ namespace Hangfire.SqlServer.RabbitMQ
         /// establish a per-queue concurrency constraint of only one job execution at a time!
         /// </remarks>
         public ushort PrefetchCount { get; set; }
+
+        internal ConnectionFactory CreateConnectionFactory()
+        {
+            var cf = new ConnectionFactory();
+
+            // Use configuration from URI, otherwise use properties
+            if (Uri != null)
+            {
+                cf.uri = Uri;
+            }
+            else
+            {
+                cf.HostName = HostName;
+                cf.Port = Port;
+                cf.UserName = Username;
+                cf.Password = Password;
+                cf.VirtualHost = VirtualHost;
+            }
+
+            return cf;
+        }
     }
 }

--- a/src/Hangfire.SqlServer.RabbitMq/RabbitMqSqlServerStorageExtensions.cs
+++ b/src/Hangfire.SqlServer.RabbitMq/RabbitMqSqlServerStorageExtensions.cs
@@ -13,25 +13,9 @@ namespace Hangfire.SqlServer.RabbitMQ
             if (configureAction == null) throw new ArgumentNullException("configureAction");
 
             var conf = new RabbitMqConnectionConfiguration();
-            configureAction(conf);
+            configureAction(conf);           
 
-            var cf = new ConnectionFactory();
-
-            // Use configuration from URI, otherwise use properties
-            if (conf.Uri != null)
-            {
-                cf.uri = conf.Uri;
-            }
-            else
-            {
-                cf.HostName = conf.HostName;
-                cf.Port = conf.Port;
-                cf.UserName = conf.Username;
-                cf.Password = conf.Password;
-                cf.VirtualHost = conf.VirtualHost;
-            }
-
-            var provider = new RabbitMqJobQueueProvider(queues, cf, channel => 
+            var provider = new RabbitMqJobQueueProvider(queues, conf.CreateConnectionFactory(), channel => 
                 channel.BasicQos(0,
                     conf.PrefetchCount,
                     false // applied separately to each new consumer on the channel

--- a/src/Hangfire.SqlServer.RabbitMq/packages.config
+++ b/src/Hangfire.SqlServer.RabbitMq/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Hangfire.Core" version="1.6.0" targetFramework="net451" />
-  <package id="Hangfire.SqlServer" version="1.6.0" targetFramework="net451" />
+  <package id="Hangfire.Core" version="1.6.15" targetFramework="net451" />
+  <package id="Hangfire.SqlServer" version="1.6.15" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="5.0.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="RabbitMQ.Client" version="4.1.1" targetFramework="net451" />

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -11,4 +11,4 @@ using System.Runtime.InteropServices;
 [assembly: CLSCompliant(false)]
 
 // Don't edit manually! Use `build.bat version` command instead!
-[assembly: AssemblyVersion("1.6.2")]
+[assembly: AssemblyVersion("1.6.3")]

--- a/tests/Hangfire.SqlServer.RabbitMq.Tests/Hangfire.SqlServer.RabbitMq.Tests.csproj
+++ b/tests/Hangfire.SqlServer.RabbitMq.Tests/Hangfire.SqlServer.RabbitMq.Tests.csproj
@@ -35,12 +35,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Hangfire.Core, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Hangfire.Core.1.6.0\lib\net45\Hangfire.Core.dll</HintPath>
+    <Reference Include="Hangfire.Core, Version=1.6.15.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hangfire.Core.1.6.15\lib\net45\Hangfire.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Hangfire.SqlServer, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Hangfire.SqlServer.1.6.0\lib\net45\Hangfire.SqlServer.dll</HintPath>
+    <Reference Include="Hangfire.SqlServer, Version=1.6.15.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hangfire.SqlServer.1.6.15\lib\net45\Hangfire.SqlServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Moq">
@@ -71,6 +71,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="RabbitMqConnectionConfigurationFacts.cs" />
+    <Compile Include="RabbitMqExtensionsFacts.cs" />
     <Compile Include="RabbitMqSqlServerStorageExtensionsFacts.cs" />
     <Compile Include="RabbitMqMonitoringApiFacts.cs" />
     <Compile Include="RabbitMqJobQueueFacts.cs" />

--- a/tests/Hangfire.SqlServer.RabbitMq.Tests/RabbitMqExtensionsFacts.cs
+++ b/tests/Hangfire.SqlServer.RabbitMq.Tests/RabbitMqExtensionsFacts.cs
@@ -1,0 +1,43 @@
+﻿using Hangfire.SqlServer.RabbitMQ;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Hangfire.SqlServer.RabbitMq.Tests
+{
+    public class RabbitMqExtensionsFacts : IDisposable
+    {
+        private readonly IGlobalConfiguration<SqlServerStorage> _globalconfiguration;
+
+        public RabbitMqExtensionsFacts()
+        {
+            _globalconfiguration = GlobalConfiguration.Configuration.UseSqlServerStorage(@"Server=.\sqlexpress;Database=TheDatabase;Trusted_Connection=True;", new SqlServerStorageOptions { PrepareSchemaIfNecessary = false });
+        }
+
+        [Fact]
+        public void UseRabbitMqQueues_ThrowsAnException_WhenConfigurationIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => RabbitMqExtensions.UseRabbitMqQueues(null, conf => conf.HostName = "localhost", null, "default"));
+
+            Assert.Equal("configuration", exception.ParamName);
+        }
+
+        [Fact]
+        public void UseRabbitMqQueues_AddsRabbitMqJobQueueProvider()
+        {
+            _globalconfiguration.UseRabbitMqQueues(conf => conf.HostName = "localhost", "default");
+
+            var providerTypes = _globalconfiguration.Entry.QueueProviders.Select(x => x.GetType());
+            Assert.Contains(typeof(RabbitMqJobQueueProvider), providerTypes);
+        }
+
+        public void Dispose()
+        {
+            foreach (var provider in _globalconfiguration.Entry.QueueProviders)
+            {
+                (provider as IDisposable)?.Dispose();
+            }
+        }
+    }
+}

--- a/tests/Hangfire.SqlServer.RabbitMq.Tests/packages.config
+++ b/tests/Hangfire.SqlServer.RabbitMq.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Hangfire.Core" version="1.6.0" targetFramework="net451" />
-  <package id="Hangfire.SqlServer" version="1.6.0" targetFramework="net451" />
+  <package id="Hangfire.Core" version="1.6.15" targetFramework="net451" />
+  <package id="Hangfire.SqlServer" version="1.6.15" targetFramework="net451" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />


### PR DESCRIPTION
1. Updated Hangfire nuget packages to the latest versions.
2. Implemented RabbitMqExtensions that will allow for the RabbitMq queues to be added with the GlobalConfiguration.Configuration.Use pattern.
    See http://docs.hangfire.io/en/latest/configuration/using-sql-server-with-msmq.html
3. Moved the creation of the RabbitMq ConnectionFactory create into an internal method in the RabbitMqConnectionConfiguration class to allow for the shared code between the RabbitMqExtensions and RabbitMqSqlServerStorageExtensions.  This also allow for the signature between the two extensions to remain uniform.
4. Add unit tests for RabbitMqExtensions.